### PR TITLE
invalid_grant error overwrite

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -119,7 +119,7 @@ func CreateClient(kubeconfigPath string, overrides *clientcmd.ConfigOverrides) (
 				if err != nil {
 					var e *oauth2.RetrieveError
 					if errors.As(err, &e) {
-						if strings.HasSuffix(err.Error(), `{"error":"invalid_grant"}`) {
+						if strings.Contains(err.Error(), "invalid_grant") {
 							return nil, fmt.Errorf("failed to refresh credentials for environment, please run 'stacc connect'")
 						}
 					}

--- a/client/client.go
+++ b/client/client.go
@@ -122,9 +122,9 @@ func CreateClient(kubeconfigPath string, overrides *clientcmd.ConfigOverrides) (
 						if strings.HasSuffix(err.Error(), `{"error":"invalid_grant"}`) {
 							return nil, fmt.Errorf("failed to refresh credentials for environment, please run 'stacc connect'")
 						}
-					} else {
-						return nil, err
 					}
+
+					return nil, err
 				}
 
 				newConfig := make(map[string]string)


### PR DESCRIPTION
Receiving `invalid_grant` from the OIDC server will now result in the error being overwritten before it is returned to inform the end user that their token failed to refresh and that they should try to run `stacc connect` again.

Example:
```
[runar cli] (main)$ stacc status
2022/01/04 15:03:44 failed to refresh credentials for environment, please run 'stacc connect'
```